### PR TITLE
Don't emit a reset code (\e[0m) if the current frame is already empty

### DIFF
--- a/src/main/java/net/kyori/ansi/ANSIComponentRendererImpl.java
+++ b/src/main/java/net/kyori/ansi/ANSIComponentRendererImpl.java
@@ -131,7 +131,8 @@ abstract class ANSIComponentRendererImpl<S> implements ANSIComponentRenderer<S> 
   private void printDifferences(final @NotNull Frame active, final @Nullable Frame target) {
     final StringBuilder builder = this.builder;
     if (target == null) {
-      Formats.emit(Formats.reset(), builder);
+      if (active.style != 0 || active.color != StyleOps.COLOR_UNSET)
+        Formats.emit(Formats.reset(), builder);
     } else if (active.style != target.style || target.color == StyleOps.COLOR_UNSET) {
       // reset, emit everything
       if (active.style != 0) Formats.emit(Formats.reset(), builder);

--- a/src/main/java/net/kyori/ansi/ANSIComponentRendererImpl.java
+++ b/src/main/java/net/kyori/ansi/ANSIComponentRendererImpl.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of ansi, licensed under the MIT License.
  *
- * Copyright (c) 2021-2022 KyoriPowered
+ * Copyright (c) 2021-2023 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -221,7 +221,7 @@ abstract class ANSIComponentRendererImpl<S> implements ANSIComponentRenderer<S> 
     }
 
     @Override
-    public String asString() {
+    public @NotNull String asString() {
       final String output = this.builder.toString();
       this.builder.delete(0, this.builder.length());
       return output;

--- a/src/main/java/net/kyori/ansi/StyleOps.java
+++ b/src/main/java/net/kyori/ansi/StyleOps.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of ansi, licensed under the MIT License.
  *
- * Copyright (c) 2021-2022 KyoriPowered
+ * Copyright (c) 2021-2023 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ public interface StyleOps<S> {
    * @since 1.0.0
    */
   enum State {
-    TRUE, FALSE, UNSET;
+    TRUE, FALSE, UNSET
   }
 
   /**


### PR DESCRIPTION
This has no real reason, other than the fact that "simple" components
like `Component.text("foo")` won't include any color codes