### PR TITLE
fix: Pushing empty style onto empty stack bleeds color

### DIFF
--- a/src/main/java/net/kyori/ansi/ANSIComponentRendererImpl.java
+++ b/src/main/java/net/kyori/ansi/ANSIComponentRendererImpl.java
@@ -31,6 +31,7 @@ import static java.util.Objects.requireNonNull;
 
 abstract class ANSIComponentRendererImpl<S> implements ANSIComponentRenderer<S> {
   private static final int MAX_DEPTH = 128;
+  private static final int UNSET = StyleOps.COLOR_UNSET;
   private final StyleOps<S> ops;
   private final ColorLevel color;
 
@@ -43,6 +44,7 @@ abstract class ANSIComponentRendererImpl<S> implements ANSIComponentRenderer<S> 
   protected ANSIComponentRendererImpl(final StyleOps<S> ops, final ColorLevel colorLevel) {
     this.ops = requireNonNull(ops, "ops");
     this.color = requireNonNull(colorLevel, "colorLevel");
+    this.active.clear();
   }
 
   private @Nullable Frame peek() {
@@ -134,17 +136,17 @@ abstract class ANSIComponentRendererImpl<S> implements ANSIComponentRenderer<S> 
     }
     final StringBuilder builder = this.builder;
     if (target == null) {
-      if (active.style != 0 || active.color != StyleOps.COLOR_UNSET)
+      if (active.style != 0 || active.color != UNSET)
         Formats.emit(Formats.reset(), builder);
-    } else if (active.style != target.style || target.color == StyleOps.COLOR_UNSET) {
+    } else if (active.style != target.style || target.color == UNSET) {
       // reset, emit everything
-      if (active.style != 0) Formats.emit(Formats.reset(), builder);
+      if (active.style != 0 || (active.color != UNSET && target.color == UNSET)) Formats.emit(Formats.reset(), builder);
       if ((target.style & Frame.BOLD) != 0) Formats.emit(Formats.bold(true), builder);
       if ((target.style & Frame.ITALICS) != 0) Formats.emit(Formats.italics(true), builder);
       if ((target.style & Frame.OBFUSCATED) != 0) Formats.emit(Formats.obfuscated(true), builder);
       if ((target.style & Frame.STRIKETHROUGH) != 0) Formats.emit(Formats.strikethrough(true), builder);
       if ((target.style & Frame.UNDERLINED) != 0) Formats.emit(Formats.underlined(true), builder);
-      if (target.color != StyleOps.COLOR_UNSET) Formats.emit(this.color.determineEscape(target.color), builder);
+      if (target.color != UNSET) Formats.emit(this.color.determineEscape(target.color), builder);
     } else if (active.color != target.color) {
       Formats.emit(this.color.determineEscape(target.color), builder);
     }
@@ -193,7 +195,7 @@ abstract class ANSIComponentRendererImpl<S> implements ANSIComponentRenderer<S> 
     }
 
     public void clear() {
-      this.color = -1;
+      this.color = UNSET;
       this.style = 0;
     }
   }

--- a/src/test/java/net/kyori/ansi/ANSIComponentRendererTest.java
+++ b/src/test/java/net/kyori/ansi/ANSIComponentRendererTest.java
@@ -70,6 +70,34 @@ class ANSIComponentRendererTest {
   }
 
   @Test
+  void testPopFollowedByEmptyPush() {
+    final Consumer<ANSIComponentRenderer<TestStyle>> action = r -> {
+      final TestStyle red = TestStyle.EMPTY.color(0xff_55_55);
+      r.pushStyle(red);
+      r.text("inside ");
+      r.popStyle(red);
+      r.pushStyle(TestStyle.EMPTY);
+      r.text("outside");
+      r.popStyle(TestStyle.EMPTY);
+    };
+    assertEquals("\u001B[38;2;255;85;85minside \u001b[0moutside", this.render(action, ColorLevel.TRUE_COLOR));
+
+    final Consumer<ANSIComponentRenderer<TestStyle>> action2 = r -> {
+      final TestStyle red = TestStyle.EMPTY.color(0xff_55_55);
+      final TestStyle green = TestStyle.EMPTY.color(0x55_ff_55);
+      r.pushStyle(green);
+      r.pushStyle(red);
+      r.text("inside ");
+      r.popStyle(red);
+      r.pushStyle(TestStyle.EMPTY);
+      r.text("outside");
+      r.popStyle(TestStyle.EMPTY);
+      r.popStyle(green);
+    };
+    assertEquals("\u001B[38;2;255;85;85minside \u001B[38;2;85;255;85moutside\u001b[0m", this.render(action2, ColorLevel.TRUE_COLOR));
+  }
+
+  @Test
   void testDeepColor() {
     assertEquals("\u001B[38;2;0;255;0mg\u001B[38;2;0;0;255mb\u001B[38;2;0;255;0mg\u001B[38;2;0;0;255mb\u001B[38;2;0;255;0mg\u001B[38;2;0;0;255mb\u001B[38;2;0;255;0mg\u001B[38;2;0;0;255mb\u001B[38;2;0;255;0mg\u001B[38;2;0;0;255mb\u001B[38;2;0;255;0mg\u001B[38;2;0;0;255mb\u001B[0m", this.render(r -> {
       final TestStyle g = TestStyle.EMPTY.color(0x00_ff_00);


### PR DESCRIPTION
Top level color was set to 0 initially before, and didn't distinguish between the top level and an unset color after popping to the top level

Will address https://github.com/PaperMC/Paper/issues/9343