### PR TITLE
fix: Don't try to use colors on non-terminals

### DIFF
--- a/src/main/java/net/kyori/ansi/ColorLevel.java
+++ b/src/main/java/net/kyori/ansi/ColorLevel.java
@@ -199,9 +199,11 @@ public enum ColorLevel {
       return ColorLevel.TRUE_COLOR;
     } else if (TERM != null && TERM.contains("256color")) {
       return ColorLevel.INDEXED_256;
+    } else if (TERM == null) {
+      return ColorLevel.NONE; // This isn't a terminal at all
     }
 
-    // Fallback
+    // Fallback, unknown type of terminal
     return ColorLevel.INDEXED_16;
   }
 


### PR DESCRIPTION
If the TERM environment variable is never set, we probably aren't in a terminal environment at all, and we shouldn't try to use colors.

Still fall back to indexed 16 if a terminal is present and we simply don't recognize it, as all terminals should at least support the bare minimum.