### PR TITLE
Use JAnsi for color level support if it exists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   testImplementation libs.junit.api
   testRuntimeOnly libs.junit.engine
   checkstyle libs.stylecheck
+  compileOnly libs.jansi
 }
 
 spotless {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=net.kyori
-version=1.0.9009-SNAPSHOT
+version=1.0.3-SNAPSHOT
 description=A library to render Minecraft chat component styles to ANSI control codes
 
 javadocPublishRoot=https://jd.advntr.dev/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=net.kyori
-version=1.0.3-SNAPSHOT
+version=1.0.9009-SNAPSHOT
 description=A library to render Minecraft chat component styles to ANSI control codes
 
 javadocPublishRoot=https://jd.advntr.dev/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 stylecheck = { module = "ca.stellardrift:stylecheck", version = "0.2.1" }
+jansi = { module = "org.fusesource.jansi:jansi", version = "2.4.0" }
 
 # unused, for renovate
 zCheckstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }

--- a/src/main/java/net/kyori/ansi/ColorLevel.java
+++ b/src/main/java/net/kyori/ansi/ColorLevel.java
@@ -195,7 +195,7 @@ public enum ColorLevel {
       try {
         Class.forName("org.fusesource.jansi.AnsiConsole");
         return JAnsiColorLevel.computeFromJAnsi();
-      } catch (ClassNotFoundException ignored) {
+      } catch (final ClassNotFoundException ignored) {
       }
     }
 

--- a/src/main/java/net/kyori/ansi/ColorLevel.java
+++ b/src/main/java/net/kyori/ansi/ColorLevel.java
@@ -191,12 +191,8 @@ public enum ColorLevel {
       // In other cases, fall through below to the environment variable based check
     }
 
-    if (System.console() != null) {
-      try {
-        Class.forName("org.fusesource.jansi.AnsiConsole");
-        return JAnsiColorLevel.computeFromJAnsi();
-      } catch (final ClassNotFoundException ignored) {
-      }
+    if (System.console() != null && JAnsiColorLevel.isAvailable()) {
+      return JAnsiColorLevel.computeFromJAnsi();
     }
 
     // TODO

--- a/src/main/java/net/kyori/ansi/ColorLevel.java
+++ b/src/main/java/net/kyori/ansi/ColorLevel.java
@@ -191,6 +191,14 @@ public enum ColorLevel {
       // In other cases, fall through below to the environment variable based check
     }
 
+    if (System.console() != null) {
+      try {
+        Class.forName("org.fusesource.jansi.AnsiConsole");
+        return JAnsiColorLevel.computeFromJAnsi();
+      } catch (ClassNotFoundException ignored) {
+      }
+    }
+
     // TODO
     // https://github.com/termstandard/colors
     if (COLORTERM != null && (COLORTERM.equals("truecolor") || COLORTERM.equals("24bit"))) {

--- a/src/main/java/net/kyori/ansi/ColorLevel.java
+++ b/src/main/java/net/kyori/ansi/ColorLevel.java
@@ -160,6 +160,7 @@ public enum ColorLevel {
 
   private static final String COLORTERM = System.getenv("COLORTERM");
   private static final String TERM = System.getenv("TERM");
+  private static final String WT_SESSION = System.getenv("WT_SESSION");
   private static int[] indexed256ColorTable = null;
 
   /**
@@ -191,10 +192,6 @@ public enum ColorLevel {
       // In other cases, fall through below to the environment variable based check
     }
 
-    if (System.console() != null && JAnsiColorLevel.isAvailable()) {
-      return JAnsiColorLevel.computeFromJAnsi();
-    }
-
     // TODO
     // https://github.com/termstandard/colors
     if (COLORTERM != null && (COLORTERM.equals("truecolor") || COLORTERM.equals("24bit"))) {
@@ -204,7 +201,13 @@ public enum ColorLevel {
     } else if (TERM != null && TERM.contains("256color")) {
       return ColorLevel.INDEXED_256;
     } else if (TERM == null) {
-      return ColorLevel.NONE; // This isn't a terminal at all
+      if (WT_SESSION != null) {
+        return ColorLevel.TRUE_COLOR; // Windows Terminal
+      } else if (System.console() != null && JAnsiColorLevel.isAvailable()) {
+        return JAnsiColorLevel.computeFromJAnsi();
+      } else {
+        return ColorLevel.NONE; // This isn't a terminal at all
+      }
     }
 
     // Fallback, unknown type of terminal

--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -27,10 +27,26 @@ import org.fusesource.jansi.AnsiColors;
 import org.fusesource.jansi.AnsiConsole;
 
 final class JAnsiColorLevel {
+  private static final Throwable UNAVAILABILITY_CAUSE;
+
+  static {
+    Throwable cause = null;
+    try {
+      Class.forName("org.fusesource.jansi.AnsiConsole");
+    } catch (final ClassNotFoundException classNotFoundException) {
+      cause = classNotFoundException;
+    }
+    UNAVAILABILITY_CAUSE = cause;
+  }
+
   private JAnsiColorLevel() {
   }
 
-  public static ColorLevel computeFromJAnsi() {
+  static boolean isAvailable() {
+    return UNAVAILABILITY_CAUSE == null;
+  }
+
+  static ColorLevel computeFromJAnsi() {
     final AnsiColors colors = AnsiConsole.out().getColors();
     if (colors == null) return ColorLevel.NONE;
     switch (colors) {

--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -1,0 +1,21 @@
+package net.kyori.ansi;
+
+import org.fusesource.jansi.AnsiColors;
+import org.fusesource.jansi.AnsiConsole;
+
+public class JAnsiColorLevel {
+  public static ColorLevel computeFromJAnsi() {
+    AnsiColors colors = AnsiConsole.out().getColors();
+    if (colors == null) return ColorLevel.NONE;
+    switch (colors) {
+      case Colors16:
+        return ColorLevel.INDEXED_16;
+      case Colors256:
+        return ColorLevel.INDEXED_256;
+      case TrueColor:
+        return ColorLevel.TRUE_COLOR;
+      default:
+        return ColorLevel.NONE;
+    }
+  }
+}

--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of ansi, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.ansi;
 
 import org.fusesource.jansi.AnsiColors;

--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -26,9 +26,12 @@ package net.kyori.ansi;
 import org.fusesource.jansi.AnsiColors;
 import org.fusesource.jansi.AnsiConsole;
 
-public class JAnsiColorLevel {
+final class JAnsiColorLevel {
+  private JAnsiColorLevel() {
+  }
+
   public static ColorLevel computeFromJAnsi() {
-    AnsiColors colors = AnsiConsole.out().getColors();
+    final AnsiColors colors = AnsiConsole.out().getColors();
     if (colors == null) return ColorLevel.NONE;
     switch (colors) {
       case Colors16:

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of ansi, licensed under the MIT License.
  *
- * Copyright (c) 2021-2022 KyoriPowered
+ * Copyright (c) 2021-2023 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,5 +29,6 @@
  */
 module net.kyori.ansi {
   exports net.kyori.ansi;
+  requires static org.fusesource.jansi;
   requires static transitive org.jetbrains.annotations;
 }

--- a/src/test/java/net/kyori/ansi/ANSIComponentRendererTest.java
+++ b/src/test/java/net/kyori/ansi/ANSIComponentRendererTest.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class ANSIComponentRendererTest {
   @Test
@@ -154,6 +155,11 @@ class ANSIComponentRendererTest {
 
     System.setProperty(ColorLevel.COLOR_LEVEL_PROPERTY, "truecolor");
     assertEquals(ColorLevel.compute(), ColorLevel.TRUE_COLOR);
+  }
+
+  @Test
+  void testComputeActuallyRuns() {
+    assertNotEquals(ColorLevel.compute(), null);
   }
 
   private String render(final Consumer<ANSIComponentRenderer<TestStyle>> action) {


### PR DESCRIPTION
If JAnsi is on the classpath, and we're on a terminal, use the color level computed by JAnsi.