### PR TITLE
Fix incompatibility with JAnsi < 2.1.0

### DIFF
--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of ansi, licensed under the MIT License.
  *
- * Copyright (c) 2023 KyoriPowered
+ * Copyright (c) 2023-2024 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -33,6 +33,7 @@ final class JAnsiColorLevel {
     Throwable cause = null;
     try {
       Class.forName("org.fusesource.jansi.AnsiConsole");
+      Class.forName("org.fusesource.jansi.AnsiColors");
     } catch (final ClassNotFoundException classNotFoundException) {
       cause = classNotFoundException;
     }


### PR DESCRIPTION
This PR fixes `JAnsiColorLevel` reporting as available on < 2.1.0 where [AnsiColors](https://github.com/fusesource/jansi/commit/235b653bbb57101dca7db3ff2f880115d781bc38#diff-8c4ab27fa0300b1b24f820b95af330ec1be8d1775fe3fc7553a659995a486bcf) does not exist and `AnsiConsole#out` has a different signature [2.1.0](https://github.com/fusesource/jansi/blame/jansi-2.1.0/src/main/java/org/fusesource/jansi/AnsiConsole.java#L413) [2.0.1](https://github.com/fusesource/jansi/blob/jansi-2.0.1/src/main/java/org/fusesource/jansi/AnsiConsole.java#L215)

Error thrown when calling `JAnsiColorLevel#compute` on JAnsi < 2.1.0
```java
java.lang.NoSuchMethodError: 'org.fusesource.jansi.AnsiPrintStream org.fusesource.jansi.AnsiConsole.out()'
        at net.kyori.ansi.JAnsiColorLevel.computeFromJAnsi(JAnsiColorLevel.java:50) ~[?:?]
        at net.kyori.ansi.ColorLevel.compute(ColorLevel.java:207) ~[?:?]
        at net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializerImpl$BuilderImpl.<init>(ANSIComponentSerializerImpl.java:151) ~[?:?]
        at net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer.builder(ANSIComponentSerializer.java:63) ~[?:?]
```