### PR TITLE
Fix terminal color on Windows

### DIFF
--- a/src/main/java/net/kyori/ansi/ColorLevel.java
+++ b/src/main/java/net/kyori/ansi/ColorLevel.java
@@ -24,6 +24,8 @@
 package net.kyori.ansi;
 
 import java.util.Locale;
+
+import jdk.internal.org.jline.utils.OSUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -159,7 +161,6 @@ public enum ColorLevel {
 
   private static final String COLORTERM = System.getenv("COLORTERM");
   private static final String TERM = System.getenv("TERM");
-  private static final String WT_SESSION = System.getenv("WT_SESSION");
   private static int[] indexed256ColorTable = null;
 
   /**
@@ -204,8 +205,8 @@ public enum ColorLevel {
       } else if (TERM.contains("-256color")) {
         return ColorLevel.INDEXED_256;
       }
-    } else if (WT_SESSION != null) {
-      return ColorLevel.TRUE_COLOR; // Windows Terminal
+    } else if (OSUtils.IS_WINDOWS) {
+      return ColorLevel.TRUE_COLOR; // We can assume that Windows always supports true color
     } else if (System.console() != null) {
       if (JAnsiColorLevel.isAvailable()) {
         return JAnsiColorLevel.computeFromJAnsi();


### PR DESCRIPTION
Fix terminal color on Windows to close [Paper#11637](https://github.com/PaperMC/Paper/issues/11637).

There is no `%TERM%` or `%COLORTERM%` environment variables set by default on Windows system, also, the `%WT_SESSION%` variable won't always exist in terminal for some reason on Windows 10+, so the `ColorLevel#compute` will return no color for most of circumstances on Windows. But we can assume that terminals on Windows always support the `truecolor` and just do a simple check to detect whether the terminal is on Windows.

Tested on Windows Server 2012 R2 / Windows Server 2019 / Windows 10 / Windows 11, Windows cygwin, and all work fine, the color come back, and can show the correct hex color it should be.