### PR TITLE
chore: switch to jline jansi

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 stylecheck = { module = "ca.stellardrift:stylecheck", version = "0.2.1" }
-jansi = { module = "org.fusesource.jansi:jansi", version = "2.4.1" }
+jansi = { module = "org.jline:jansi", version = "4.0.9" }
 
 # unused, for renovate
 zCheckstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }

--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.ansi;
 
-import org.fusesource.jansi.AnsiColors;
-import org.fusesource.jansi.AnsiConsole;
+import org.jline.jansi.AnsiColors;
+import org.jline.jansi.AnsiConsole;
 
 final class JAnsiColorLevel {
   private static final Throwable UNAVAILABILITY_CAUSE;
@@ -32,8 +32,8 @@ final class JAnsiColorLevel {
   static {
     Throwable cause = null;
     try {
-      Class.forName("org.fusesource.jansi.AnsiConsole");
-      Class.forName("org.fusesource.jansi.AnsiColors");
+      Class.forName("org.jline.jansi.AnsiConsole");
+      Class.forName("org.jline.jansi.AnsiColors");
     } catch (final ClassNotFoundException classNotFoundException) {
       cause = classNotFoundException;
     }

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -29,6 +29,6 @@
  */
 module net.kyori.ansi {
   exports net.kyori.ansi;
-  requires static org.fusesource.jansi;
+  requires static org.jline.jansi;
   requires static transitive org.jetbrains.annotations;
 }


### PR DESCRIPTION
[fuesource jansi](https://github.com/fusesource/jansi) is deprecated ans was moved to jline