### PR TITLE
fix: prevent classloader leak caused by static Throwable retention

### DIFF
--- a/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
+++ b/src/main/java/net/kyori/ansi/JAnsiColorLevel.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of ansi, licensed under the MIT License.
  *
- * Copyright (c) 2023-2024 KyoriPowered
+ * Copyright (c) 2023-2026 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,24 +27,25 @@ import org.fusesource.jansi.AnsiColors;
 import org.fusesource.jansi.AnsiConsole;
 
 final class JAnsiColorLevel {
-  private static final Throwable UNAVAILABILITY_CAUSE;
+  private static final boolean AVAILABLE;
 
   static {
-    Throwable cause = null;
+    boolean available;
     try {
       Class.forName("org.fusesource.jansi.AnsiConsole");
       Class.forName("org.fusesource.jansi.AnsiColors");
+      available = true;
     } catch (final ClassNotFoundException classNotFoundException) {
-      cause = classNotFoundException;
+      available = false;
     }
-    UNAVAILABILITY_CAUSE = cause;
+    AVAILABLE = available;
   }
 
   private JAnsiColorLevel() {
   }
 
   static boolean isAvailable() {
-    return UNAVAILABILITY_CAUSE == null;
+    return AVAILABLE;
   }
 
   static ColorLevel computeFromJAnsi() {


### PR DESCRIPTION
This change removes the static `Throwable` reference used to store the JAnsi availability failure.

Retaining `ClassNotFoundException` in a static field may keep references to classes and classloader metadata through the captured stack trace and exception context, potentially preventing classloader garbage collection in reloadable/plugin-based environments.

The implementation now stores only the availability state instead of the original exception instance.

The attached screenshot shows the observed retention path from the static exception reference to the affected classloader.
<img width="2107" height="532" alt="javaw_LNMRL1JkyO" src="https://github.com/user-attachments/assets/577f9d06-4ac8-4d63-b61b-127144f379b7" />

